### PR TITLE
Option to order AAT results by term

### DIFF
--- a/app/lib/Plugins/InformationService/AAT.php
+++ b/app/lib/Plugins/InformationService/AAT.php
@@ -62,7 +62,18 @@ class WLPlugInformationServiceAAT extends BaseGettyLODServicePlugin implements I
 			'label' => _t('Additional sparql suffix'),
 			'description' => _t('Applied after the initial search. Useful to combine filters. For example to limit to children of particular terms enter "?ID gvp:broaderPreferredExtended ?Extended FILTER (?Extended IN (aat:300261086, aat:300264550))"')
 		];
-
+		$g_information_service_settings_AAT['orderBy'] = [
+			'formatType' => FT_TEXT,
+			'display_Type' => DT_FIELD,
+			'default' => '',
+			'width' => 90, 'height' => 1,
+			'label' => _t("Order by"),
+			'description' => _t("How the auto complete list will be ordered. Default is how AAT return the results. Label is by the visible label"),
+			'options' => array(
+				_t("Default") => "Order",
+				_t("Label") => "TermPrefLabel"
+			),
+		];		
 		WLPlugInformationServiceAAT::$s_settings = $g_information_service_settings_AAT;
 		parent::__construct();
 		$this->info['NAME'] = 'AAT';
@@ -134,6 +145,7 @@ class WLPlugInformationServiceAAT extends BaseGettyLODServicePlugin implements I
 			$vs_additional_filter = "$vs_additional_filter ;";
 		}
 		$vs_sparql_suffix = $pa_options['settings']['sparqlSuffix'] ?? null;
+		$vs_order_by = caGetOption( 'orderBy', $pa_options['settings'], 'Order');
 		$vs_query = urlencode( 'SELECT ?ID ?TermPrefLabel ?Parents ?ParentsFull {
 	?ID a skos:Concept; ' . $pa_params['search_field'] . ' "' . $ps_search . '"; skos:inScheme aat: ; ' . $vs_additional_filter . '
 	gvp:prefLabelGVP [xl:literalForm ?TermPrefLabel].
@@ -141,7 +153,8 @@ class WLPlugInformationServiceAAT extends BaseGettyLODServicePlugin implements I
 	{?ID gvp:parentString ?ParentsFull}
 	{?ID gvp:displayOrder ?Order}
 	 ' . $vs_sparql_suffix . '
-	} LIMIT ' . $pa_params['limit'] );
+	} 	ORDER BY ?' . $vs_order_by . '
+		LIMIT ' . $pa_params['limit'] );
 		return $vs_query;
 	}
 


### PR DESCRIPTION
A simple addition to allow admins to select to order the results by the term or leave it in the default order.